### PR TITLE
Update d_main.h

### DIFF
--- a/d_main.h
+++ b/d_main.h
@@ -37,6 +37,7 @@
 extern char*		wadfiles[MAXWADFILES];
 
 void D_AddFile (char *file);
+int SDL_SYS_TimerInit(void);
 
 
 


### PR DESCRIPTION
Fix compiler warning:
d_main.c:1009: warning: implicit declaration of function `SDL_SYS_TimerInit'